### PR TITLE
Refactor mutable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Haxe Interpreter",
             "type": "haxe-eval",
             "request": "launch",
-			"args": ["scripts/eval_debug.hxml"]
+			"args": ["scripts/eval_debug.hxml", "test/Testbed.cosy"]
         }
     ]
 }

--- a/scripts/common.hxml
+++ b/scripts/common.hxml
@@ -4,4 +4,6 @@
 -dce full
 -D analyzer-optimize
 
+# -D warn_var_shadowing
+
 # --macro nullSafety("cosy", Strict)

--- a/src/cosy/Expr.hx
+++ b/src/cosy/Expr.hx
@@ -11,7 +11,7 @@ enum Expr {
     Assign(name: Token, op: Token, value: Expr);
     Binary(left: Expr, op: Token, right: Expr);
     Call(callee: Expr, paren: Token, arguments: Array<Expr>);
-    Get(obj: Expr, name: Token);
+    Get(obj: Expr, name: Token); // TODO: `name` should be the first argument
     GetIndex(obj: Expr, ranged: Bool, from: Null<Expr>, to: Null<Expr>);
     Grouping(e: Expr);
     Literal(v: Any);

--- a/src/cosy/Logging.hx
+++ b/src/cosy/Logging.hx
@@ -203,7 +203,7 @@ function report(fileName: String, sourceCode: String, error: ScriptError) {
 }
 
 function color(text: String, type: LogType): String {
-    // return text; // TODO: Temp!
+    return text; // TODO: Temp!
     // if (noColors) return text;
     return switch type {
         case RuntimeError: '\033[1;31m$text\033[0m';

--- a/src/cosy/Logging.hx
+++ b/src/cosy/Logging.hx
@@ -36,6 +36,7 @@ enum LogType {
     Warning;
     Hint;
     Misc;
+    Gray;
 }
 
 typedef ScriptError = {
@@ -195,14 +196,14 @@ function report(fileName: String, sourceCode: String, error: ScriptError) {
             s += color([for (i in 0...len) '^'].join('') + ' ${error.message}', errorType);
             println(s);
         } else {
-            println(lineDecoration + codeLine);
+            println(color(lineDecoration + codeLine, Gray));
         }
     }
     println();
 }
 
 function color(text: String, type: LogType): String {
-    return text; // TODO: Temp!
+    // return text; // TODO: Temp!
     // if (noColors) return text;
     return switch type {
         case RuntimeError: '\033[1;31m$text\033[0m';
@@ -210,6 +211,7 @@ function color(text: String, type: LogType): String {
         case Warning: '\033[0;33m$text\033[0m';
         case Hint: '\033[0;36m$text\033[0m';
         case Misc: '\033[0;35m$text\033[0m';
+        case Gray: '\u001b[38;5;240m${text}';
     }
 }
 

--- a/src/cosy/Stmt.hx
+++ b/src/cosy/Stmt.hx
@@ -8,7 +8,7 @@ enum Stmt {
     Continue(keyword: Token);
     Expression(e: Expr);
     For(keyword: Token, name: Token, from: Expr, to: Expr, body: Array<Stmt>);
-    ForArray(name: Token, array: Expr, body: Array<Stmt>);
+    ForArray(name: Token, mut: Bool, array: Expr, body: Array<Stmt>);
     ForCondition(keyword: Token, ?cond: Expr, body: Array<Stmt>);
     Function(name: Token, params: Array<Param>, body: Array<Stmt>, returnType: ComputedVariableType, foreign: Bool);
     If(keyword: Token, cond: Expr, then: Stmt, el: Null<Stmt>);

--- a/src/cosy/Stmt.hx
+++ b/src/cosy/Stmt.hx
@@ -15,5 +15,5 @@ enum Stmt {
     Print(keyword: Token, e: Expr);
     Return(keyword: Token, value: Expr);
     Struct(name: Token, declarations: Array<Stmt>);
-    Let(name: Token, type: VariableType, init: Expr, mut: Bool, foreign: Bool); // TODO: `type` should be ComputedVariableType
+    Let(v: Variable, init: Expr);
 }

--- a/src/cosy/Variable.hx
+++ b/src/cosy/Variable.hx
@@ -1,7 +1,8 @@
 package cosy;
 
-typedef Param = {
+typedef Variable = {
     name: Token,
     type: VariableType /* TODO: Should be ComputedVariableType */,
     mut: Bool,
+    foreign: Bool,
 }

--- a/src/cosy/VariableType.hx
+++ b/src/cosy/VariableType.hx
@@ -9,9 +9,8 @@ enum VariableType {
     Instance;
     Function(paramTypes: Array<VariableType>, returnType: VariableType);
     Array(type: VariableType);
-    Struct(variables: Map<String, VariableType>);
+    Struct(variables: Map<String, Variable>);
     NamedStruct(name: String);
-    Mutable(type: VariableType);
 }
 
 typedef ComputedVariableType = {

--- a/src/cosy/VariableType.hx
+++ b/src/cosy/VariableType.hx
@@ -10,7 +10,7 @@ enum VariableType {
     Function(paramTypes: Array<VariableType>, returnType: VariableType);
     Array(type: VariableType);
     Struct(variables: Map<String, Variable>);
-    NamedStruct(name: String, ?mutable: Bool);
+    NamedStruct(name: String, mutable: Bool);
 }
 
 typedef ComputedVariableType = {

--- a/src/cosy/VariableType.hx
+++ b/src/cosy/VariableType.hx
@@ -10,7 +10,7 @@ enum VariableType {
     Function(paramTypes: Array<VariableType>, returnType: VariableType);
     Array(type: VariableType);
     Struct(variables: Map<String, Variable>);
-    NamedStruct(name: String);
+    NamedStruct(name: String, ?mutable: Bool);
 }
 
 typedef ComputedVariableType = {

--- a/src/cosy/phases/AstPrinter.hx
+++ b/src/cosy/phases/AstPrinter.hx
@@ -56,8 +56,7 @@ class AstPrinter {
             case Print(keyword, e): '${keyword.lexeme} ${printExpr(e)}';
             case Return(keyword, value): keyword.lexeme + (value != null ? ' ${printExpr(value)}' : '');
             case Struct(name, declarations): 'struct ${name.lexeme} ${printBlock(declarations)}';
-            case Let(name, type, init, mut, foreign): '${foreign ? "foreign " : ""}${mut ? "mut" : "let"} ${name.lexeme}'
-                + (init != null ? ' = ${printExpr(init)}' : '');
+            case Let(v, init): '${v.foreign ? "foreign " : ""}${v.mut ? "mut" : "let"} ${v.name.lexeme}' + (init != null ? ' = ${printExpr(init)}' : '');
         }
     }
 

--- a/src/cosy/phases/AstPrinter.hx
+++ b/src/cosy/phases/AstPrinter.hx
@@ -42,7 +42,7 @@ class AstPrinter {
             case Continue(keyword): keyword.lexeme;
             case Expression(e): '${printExpr(e)}';
             case For(keyword, name, from, to, body): 'for ${name != null ? name.lexeme + " in " : ""}${printExpr(from)}..${printExpr(to)} ${printBlock(body)}';
-            case ForArray(name, array, body): 'for ${name.lexeme} in ${printExpr(array)} ${printBlock(body)}';
+            case ForArray(name, mut, array, body): 'for ${mut ? "mut " : ""}${name.lexeme} in ${printExpr(array)} ${printBlock(body)}';
             case ForCondition(keyword, cond, body): '${keyword.lexeme} ${cond != null ? printExpr(cond) : ""} ${printBlock(body)}';
             case Function(name, params, body, returnType, foreign):
                 var declaration = '${foreign ? "foreign fn" : "fn"} ${name.lexeme}';

--- a/src/cosy/phases/CodeGenerator.hx
+++ b/src/cosy/phases/CodeGenerator.hx
@@ -117,10 +117,10 @@ class CodeGenerator {
                 add_token(keyword);
                 genExpr(expr);
                 emit(Print);
-            case Let(name, type, init, mut, foreign):
-                add_token(name);
+            case Let(v, init):
+                add_token(v.name);
                 genExpr(init);
-                localIndexes[name.lexeme] = localsCounter++;
+                localIndexes[v.name.lexeme] = localsCounter++;
             case Block(statements):
                 var previousLocalsCounter = localsCounter;
                 genStmts(statements);

--- a/src/cosy/phases/Interpreter.hx
+++ b/src/cosy/phases/Interpreter.hx
@@ -130,15 +130,15 @@ class Interpreter {
                 final fields: Map<String, Any> = new Map();
                 for (decl in declarations)
                     switch decl {
-                        case Let(name, type, init, mut, foreign): fields.set(name.lexeme, init != null ? evaluate(init) : null);
+                        case Let(v, init): fields.set(v.name.lexeme, init != null ? evaluate(init) : null);
                         case _: // should never happen
                     }
                 environment = previousEnv;
                 final struct = new StructInstance(name, fields, logger);
                 environment.assign(name, struct);
-            case Let(name, type, init, mut, foreign):
-                if (foreign) {
-                    environment.define(name.lexeme, compiler.foreignVariables[name.lexeme]);
+            case Let(v, init):
+                if (v.foreign) {
+                    environment.define(v.name.lexeme, compiler.foreignVariables[v.name.lexeme]);
                     return;
                 }
 
@@ -149,10 +149,10 @@ class Interpreter {
                 //     value = (value: StructInstance).clone();
                 // }
                 if (!hotReload) {
-                    environment.define(name.lexeme, value);
+                    environment.define(v.name.lexeme, value);
                 } else {
                     // Hack for hot reload to disregard already setup variables
-                    if (init != null) environment.define(name.lexeme, value);
+                    if (init != null) environment.define(v.name.lexeme, value);
                 }
         }
     }

--- a/src/cosy/phases/Interpreter.hx
+++ b/src/cosy/phases/Interpreter.hx
@@ -82,7 +82,7 @@ class Interpreter {
                 } catch (err: Break) {
                     // do nothing
                 }
-            case ForArray(name, array, body):
+            case ForArray(name, mut, array, body):
                 final arr: Array<Any> = evaluate(array); // TODO: Implicit cast to array :(
                 final env = new Environment(environment);
                 try {

--- a/src/cosy/phases/JavaScriptPrinter.hx
+++ b/src/cosy/phases/JavaScriptPrinter.hx
@@ -42,9 +42,9 @@ class JavaScriptPrinter {
             case Print(keyword, e): 'console.log(${printExpr(e)});';
             case Struct(name, declarations): '// ${name.lexeme} struct';
             case Return(keyword, value): 'return' + (value != null ? ' ${printExpr(value)}' : '') + ';';
-            case Let(name, type, init, mut, foreign):
-                if (foreign) return ''; // TODO: Is this correct behavior?
-                '${mut ? "var" : "const"} ${name.lexeme}' + (init != null ? ' = ${printExpr(init)}' : '') + ';';
+            case Let(v, init):
+                if (v.foreign) return ''; // TODO: Is this correct behavior?
+                '${v.mut ? "var" : "const"} ${v.name.lexeme}' + (init != null ? ' = ${printExpr(init)}' : '') + ';';
         }
     }
 

--- a/src/cosy/phases/JavaScriptPrinter.hx
+++ b/src/cosy/phases/JavaScriptPrinter.hx
@@ -30,7 +30,7 @@ class JavaScriptPrinter {
             case For(keyword, name, from, to, body):
                 var counter = (name != null ? name.lexeme : '__i');
                 'for (var $counter = ${printExpr(from)}; $counter < ${printExpr(to)}; $counter++) ${printBlock(body)}';
-            case ForArray(name, array, body): 'for (${name.lexeme} of ${printExpr(array)}) ${printBlock(body)}';
+            case ForArray(name, mut, array, body): 'for (${name.lexeme} of ${printExpr(array)}) ${printBlock(body)}';
             case ForCondition(keyword, cond, body): 'while (${cond != null ? printExpr(cond) : "true"}) ${printBlock(body)}';
             case Function(name, params, body, returnType, foreign):
                 if (foreign) return ''; // TODO: Is this correct behavior?

--- a/src/cosy/phases/MarkdownPrinter.hx
+++ b/src/cosy/phases/MarkdownPrinter.hx
@@ -69,8 +69,8 @@ ${astPrinter.printStmts(body)}
                 for (decl in declarations) {
                     var res = '- ';
                     switch decl {
-                        case Let(name, type, init, mut, foreign):
-                            res += '`${name.lexeme}` ${type.formatType()} ${(init != null ? "= " + printExpr(init) : "")}';
+                        case Let(v, init):
+                            res += '`${v.name.lexeme}` ${v.type.formatType()} ${(init != null ? "= " + printExpr(init) : "")}';
                         case _:
                     }
                     print(res);

--- a/src/cosy/phases/Optimizer.hx
+++ b/src/cosy/phases/Optimizer.hx
@@ -25,7 +25,7 @@ class Optimizer {
             case Expression(e): Expression(optimizeExpr(e));
             case If(keyword, cond, then, el): If(keyword, optimizeExpr(cond), optimizeStmt(then), (el != null ? optimizeStmt(el) : null));
             case Print(keyword, e): Print(keyword, optimizeExpr(e));
-            case Let(name, type, init, mut, foreign): Let(name, type, (init != null ? optimizeExpr(init) : init), mut, foreign);
+            case Let(v, init): Let(v, (init != null ? optimizeExpr(init) : init));
             case Return(keyword, value): Return(keyword, (value != null ? optimizeExpr(value) : null));
             case _: stmt;
         }

--- a/src/cosy/phases/Parser.hx
+++ b/src/cosy/phases/Parser.hx
@@ -137,7 +137,12 @@ class Parser {
         var initializer = null;
         if (!foreign && match([Equal])) initializer = expression();
 
-        return Let(name, type, initializer, mut, foreign);
+        return Let({
+            name: name,
+            type: type,
+            mut: mut,
+            foreign: foreign
+        }, initializer);
     }
 
     function structDeclaration(): Stmt {
@@ -215,9 +220,8 @@ class Parser {
                         case Array(_):
                         case _: error(name, 'Only struct and array parameters can be marked as `mut`.');
                     }
-                    type = Mutable(type);
                 }
-                params.push({name: name, type: type});
+                params.push({name: name, type: type, mut: mutable});
             } while (match([Comma]));
         }
 

--- a/src/cosy/phases/Parser.hx
+++ b/src/cosy/phases/Parser.hx
@@ -72,6 +72,7 @@ class Parser {
         } else if (checkUntil(In, LeftBrace)) {
             // ForArray:
             // for i in [3,4,5]
+            final mutable = match([Mut]);
             var name = consume(Identifier, 'Expect variable name.');
             consume(In, 'Expect "in" after for loop identifier.');
 
@@ -80,7 +81,7 @@ class Parser {
             consume(LeftBrace, 'Expect "{" before loop body.');
             var body = block();
 
-            ForArray(name, array, body);
+            ForArray(name, mutable, array, body);
         } else {
             // ForCondition:
             // for i < 10

--- a/src/cosy/phases/Parser.hx
+++ b/src/cosy/phases/Parser.hx
@@ -196,9 +196,12 @@ class Parser {
             Function(funcParamTypes, returnType);
         } else if (match([ArrayType])) {
             Array(paramType());
+        } else if (match([Mut]) && check(Identifier) && structNames.indexOf(peek().lexeme) != -1) {
+            var identifier = advance();
+            NamedStruct(identifier.lexeme, true);
         } else if (check(Identifier) && structNames.indexOf(peek().lexeme) != -1) {
             var identifier = advance();
-            NamedStruct(identifier.lexeme);
+            NamedStruct(identifier.lexeme, false);
         } else {
             Unknown;
         }

--- a/src/cosy/phases/Resolver.hx
+++ b/src/cosy/phases/Resolver.hx
@@ -201,7 +201,7 @@ class Resolver {
         // var f Array Field = []
         // trace(type);
         switch type {
-            case NamedStruct(structName):
+            case NamedStruct(structName, mut):
                 var i = scopes.length - 1;
                 while (i >= 0) {
                     var scope = scopes.get(i);

--- a/src/cosy/phases/Resolver.hx
+++ b/src/cosy/phases/Resolver.hx
@@ -78,7 +78,7 @@ class Resolver {
                 if (body.length == 0) logger.error(keyword, 'Loop body is empty.');
                 resolveStmts(body);
                 endScope();
-            case ForArray(name, array, body):
+            case ForArray(name, mut, array, body):
                 resolveExpr(array);
 
                 beginScope();

--- a/src/cosy/phases/Typer.hx
+++ b/src/cosy/phases/Typer.hx
@@ -83,11 +83,27 @@ class Typer {
                 }
                 if (name != null) setVariableType(name, Number);
                 typeStmts(body);
-            case ForArray(name, array, body):
+            case ForArray(name, mut, array, body):
                 var arrayType = typeExpr(array);
                 switch arrayType {
-                    case Array(t): setVariableType(name, t);
-                    case Unknown: setVariableType(name, Unknown);
+                    case Array(t):
+                        variableTypes.set(name.lexeme, {
+                            name: name,
+                            type: switch t {
+                                case NamedStruct(name,
+                                    mutable): NamedStruct(name, mut); // HACK to ensure that NamedStructs are set as mutable when the loop variable is
+                                case _: t;
+                            },
+                            mut: mut,
+                            foreign: false,
+                        });
+                    case Unknown:
+                        variableTypes.set(name.lexeme, {
+                            name: name,
+                            type: Unknown,
+                            mut: mut,
+                            foreign: false,
+                        });
                     case _: logger.error(name, 'Can only loop over value of type array.');
                 }
                 typeStmts(body);

--- a/test/examples/advent-of-code-2021/day12.cosy
+++ b/test/examples/advent-of-code-2021/day12.cosy
@@ -38,8 +38,8 @@ for path in input {
     }
 }
 
-fn get_cave(name Str) Cave {
-    for cave in caves {
+fn get_cave(name Str) mut Cave {
+    for mut cave in caves {
         if cave.name == name {
             return cave
         }

--- a/test/scripts/struct-errors.cosy.stdout
+++ b/test/scripts/struct-errors.cosy.stdout
@@ -26,7 +26,7 @@
 30 |     point.x = 555
 31 |     point.y = 7 // fails (y is not mut)
 32 |     point.z = 8 // fails (z is not a member)
-               ^ No member named "z" in struct of type Struct { a Array(Num), x Mut(Num), y Num }
+               ^ No member named "z" in struct of type Struct { a Array(Num), x Num, y Num }
 33 |     point.w = fn() { // fails (w is not a member)
 34 |     	print 'hello'
 
@@ -34,7 +34,7 @@
 31 |     point.y = 7 // fails (y is not mut)
 32 |     point.z = 8 // fails (z is not a member)
 33 |     point.w = fn() { // fails (w is not a member)
-               ^ No member named "w" in struct of type Struct { a Array(Num), x Mut(Num), y Num }
+               ^ No member named "w" in struct of type Struct { a Array(Num), x Num, y Num }
 34 |     	print 'hello'
 35 |     }
 
@@ -42,7 +42,7 @@
 40 | {
 41 |     mut p = Point { a = [] }
 42 |     p = Fake {} // fails (Point type != Fake type)
-         ^ Cannot assign Struct { a Mut(Str), x Mut(Num) } to Struct { a Array(Num), x Mut(Num), y Num }
+         ^ Cannot assign Struct { a Str, x Num } to Struct { a Array(Num), x Num, y Num }
 43 |     print p
 44 | }
 

--- a/test/scripts/type-checking.cosy.stdout
+++ b/test/scripts/type-checking.cosy.stdout
@@ -54,6 +54,14 @@
 67 |     print x
 68 | }
 
+■ test/scripts/type-checking.cosy, line 67:
+65 |     }
+66 |     mut x = f()
+67 |     print x
+         ^^^^^ Cannot print values of type void.
+68 | }
+69 | 
+
 ■ test/scripts/type-checking.cosy, line 85:
 83 | 
 84 | {

--- a/wishlist.md
+++ b/wishlist.md
@@ -84,7 +84,7 @@ fun x() { print "hej" }
 - [x] Remove unused testing code (Cosy.hx + tests/)
 - [ ] Make array concat be simply `+` (or `++` like in Haskell?)
 - [ ] Perserve ordering of members when printing a struct
-- [ ] Remove `Mutable` as a type in Typer and try an alternative implemention (e.g. metadata)
+- [x] Remove `Mutable` as a type in Typer and try an alternative implemention (e.g. metadata)
 - [x] Make a new and improved Hangman example with properly typed code, structs and arrays
 - [ ] Update Cosy basics example with structs, functions taking mut struct, string functions
 - [ ] Submit Cosy example to "99 bottles" site (http://www.99-bottles-of-beer.net/submitnewlanguage.html)
@@ -127,6 +127,7 @@ fun x() { print "hej" }
 - [ ] Make an annotation for pure functions
 - [ ] Make an annotation for memorizing a function (i.e. cache inputs => output)
 - [ ] A way to initialize a list with a size (like in C++; `vector<int>(height, vector<int>(width, 0)))`)
+- [ ] Find a more elegant way of handling variable/parameter/return type/loop variable/named struct mutability. I may have to replace some enums with structures.
 
 # Project wishlist
 - [ ] Make a syntax highlighting extension for vscode


### PR DESCRIPTION
Removes the `Mutable` enum value and replaces it with a `Variable` structure containing a `mut` flag.

However, there's some complications regarding storing and accessing mutability flags of variables/parameters/return types/loop variables/named structs in a common way. This is something I would like to improve and make more elegant. I don't have a solution for this issue yet, however.