### PR TITLE
Add entity component system functionality

### DIFF
--- a/.haxerc
+++ b/.haxerc
@@ -1,4 +1,4 @@
 {
-  "version": "4.2.5",
+  "version": "4.3.0",
   "resolveLibs": "scoped"
 }

--- a/scripts/common.hxml
+++ b/scripts/common.hxml
@@ -4,6 +4,16 @@
 -dce full
 -D analyzer-optimize
 
+# from here: https://github.com/HaxeFoundation/haxe/issues/10908
+# -D analyzer-module
+# -D analyzer-optimize
+# -D analyzer-user-var-fusion
+# -D analyzer-const_propagation
+# -D analyzer-copy_propagation
+# -D analyzer-local_dce
+# -D analyzer-fusion
+# -D analyzer-purity_inference
+
 # -D warn_var_shadowing
 
 # --macro nullSafety("cosy", Strict)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -2,10 +2,10 @@
 # haxe scripts/jvm.hxml && java -jar bin/jvm/cosy.jar $@ 
 
 # Target: Node (JavaScript)
-haxe scripts/node.hxml && node bin/node/cosy.js $@
+# haxe scripts/node.hxml && node bin/node/cosy.js $@
 
 # Target: C++
 # haxe scripts/cpp.hxml && ./bin/cpp/cosy $@
 
 # Target: Haxe Eval
-# haxe scripts/eval_debug.hxml $@
+haxe scripts/eval_debug.hxml $@

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,8 +1,11 @@
-# haxe jvm.hxml && java -jar bin/jvm/cosy.jar $@ 
-# haxe jvm.hxml && cp bin/js/cosy.js docs/playground/cosy.js && java -jar bin/jvm/cosy.jar $@ 
+# Target: Java
+# haxe scripts/jvm.hxml && java -jar bin/jvm/cosy.jar $@ 
 
-# haxe -cp src -D no-inline --run cosy.Cosy $@
+# Target: Node (JavaScript)
+haxe scripts/node.hxml && node bin/node/cosy.js $@
 
-# haxe scripts/node.hxml && node bin/node/cosy.js $@
-# haxe -cp src --run cosy.Cosy $@
-haxe scripts/eval_debug.hxml $@
+# Target: C++
+# haxe scripts/cpp.hxml && ./bin/cpp/cosy $@
+
+# Target: Haxe Eval
+# haxe scripts/eval_debug.hxml $@

--- a/src/composite
+++ b/src/composite
@@ -1,0 +1,1 @@
+../../composite/src/composite

--- a/src/cosy/Expr.hx
+++ b/src/cosy/Expr.hx
@@ -24,6 +24,7 @@ enum Expr {
     Unary(op: Token, right: Expr);
     Variable(name: Token);
     AnonFunction(params: Array<Param>, body: Array<Stmt>, returnType: ComputedVariableType);
+    Print(keyword: Token, e: Expr);
 
     Spawn(keyword: Token, args: Array<Expr>);
 }

--- a/src/cosy/Expr.hx
+++ b/src/cosy/Expr.hx
@@ -24,4 +24,6 @@ enum Expr {
     Unary(op: Token, right: Expr);
     Variable(name: Token);
     AnonFunction(params: Array<Param>, body: Array<Stmt>, returnType: ComputedVariableType);
+
+    Spawn(keyword: Token, args: Array<Expr>);
 }

--- a/src/cosy/QueryArg.hx
+++ b/src/cosy/QueryArg.hx
@@ -2,7 +2,7 @@ package cosy;
 
 typedef QueryArg = {
     structName: Token,
-    name: Token,
+    name: Null<Token>,
     mut: Bool,
-    // not: Bool,
+    not: Bool,
 }

--- a/src/cosy/QueryArg.hx
+++ b/src/cosy/QueryArg.hx
@@ -3,6 +3,6 @@ package cosy;
 typedef QueryArg = {
     structName: Token,
     name: Token,
+    mut: Bool,
     // not: Bool,
-    // mut: Bool,
 }

--- a/src/cosy/QueryArg.hx
+++ b/src/cosy/QueryArg.hx
@@ -1,0 +1,8 @@
+package cosy;
+
+typedef QueryArg = {
+    structName: Token,
+    name: Token,
+    // not: Bool,
+    // mut: Bool,
+}

--- a/src/cosy/Stmt.hx
+++ b/src/cosy/Stmt.hx
@@ -1,5 +1,6 @@
 package cosy;
 
+import cosy.QueryArg;
 import cosy.VariableType;
 
 enum Stmt {
@@ -16,4 +17,6 @@ enum Stmt {
     Return(keyword: Token, value: Expr);
     Struct(name: Token, declarations: Array<Stmt>);
     Let(v: Variable, init: Expr);
+
+    Query(keyword: Token, queryArgs: Array<QueryArg>, body: Array<Stmt>);
 }

--- a/src/cosy/Stmt.hx
+++ b/src/cosy/Stmt.hx
@@ -13,7 +13,6 @@ enum Stmt {
     ForCondition(keyword: Token, ?cond: Expr, body: Array<Stmt>);
     Function(name: Token, params: Array<Param>, body: Array<Stmt>, returnType: ComputedVariableType, foreign: Bool);
     If(keyword: Token, cond: Expr, then: Stmt, el: Null<Stmt>);
-    Print(keyword: Token, e: Expr);
     Return(keyword: Token, value: Expr);
     Struct(name: Token, declarations: Array<Stmt>);
     Let(v: Variable, init: Expr);

--- a/src/cosy/StructInstance.hx
+++ b/src/cosy/StructInstance.hx
@@ -6,14 +6,10 @@ class StructInstance {
     final fields: Map<String, Any>;
     final logger: cosy.Logging.Logger;
 
-    // static var ID = 0;
-    // public final id: Int;
-
     public function new(name: Token, fields: Map<String, Any>, logger: cosy.Logging.Logger) {
         this.structName = name;
         this.fields = fields;
         this.logger = logger;
-        // this.id = ID++;
     }
 
     public function clone() { // Make a deep copy of fields

--- a/src/cosy/StructInstance.hx
+++ b/src/cosy/StructInstance.hx
@@ -1,14 +1,19 @@
 package cosy;
 
 class StructInstance {
-    final structName: Token;
+    public final structName: Token;
+
     final fields: Map<String, Any>;
     final logger: cosy.Logging.Logger;
+
+    // static var ID = 0;
+    // public final id: Int;
 
     public function new(name: Token, fields: Map<String, Any>, logger: cosy.Logging.Logger) {
         this.structName = name;
         this.fields = fields;
         this.logger = logger;
+        // this.id = ID++;
     }
 
     public function clone() { // Make a deep copy of fields

--- a/src/cosy/TokenType.hx
+++ b/src/cosy/TokenType.hx
@@ -58,4 +58,7 @@ enum TokenType {
     FunctionType;
     ArrayType;
     Eof;
+
+    Spawn;
+    Query;
 }

--- a/src/cosy/VariableType.hx
+++ b/src/cosy/VariableType.hx
@@ -10,6 +10,7 @@ enum VariableType {
     Array(type: VariableType);
     Struct(variables: Map<String, Variable>);
     NamedStruct(name: String, mutable: Bool);
+    Entity;
 }
 
 typedef ComputedVariableType = {

--- a/src/cosy/phases/AstPrinter.hx
+++ b/src/cosy/phases/AstPrinter.hx
@@ -58,7 +58,15 @@ class AstPrinter {
             case Struct(name, declarations): 'struct ${name.lexeme} ${printBlock(declarations)}';
             case Let(v, init): '${v.foreign ? "foreign " : ""}${v.mut ? "mut" : "let"} ${v.name.lexeme}' + (init != null ? ' = ${printExpr(init)}' : '');
 
-            case Query(keyword, queryArgs, body): throw 'not implemented'; // TODO: Implement
+            case Query(keyword, queryArgs, body):
+                var s = '${keyword.lexeme} ';
+                for (arg in queryArgs) {
+                    if (arg.not) s += '!';
+                    if (arg.mut) s += 'mut ';
+                    if (arg.name != null) s += arg.name.lexeme;
+                    s += arg.structName.lexeme;
+                }
+                '$s ${printBlock(body)}';
         }
     }
 
@@ -95,7 +103,9 @@ class AstPrinter {
                 var retType = returnType.annotated.formatType(true);
                 if (retType != '') retType = ' $retType';
                 'fn($parameters)$retType $block';
-            case Spawn(keyword, args): 'SPAWN!';
+            case Spawn(keyword, args):
+                var sArgs = [for (arg in args) printExpr(arg)].join(', ');
+                '${keyword.lexeme}($sArgs)';
         }
     }
 

--- a/src/cosy/phases/AstPrinter.hx
+++ b/src/cosy/phases/AstPrinter.hx
@@ -1,7 +1,5 @@
 package cosy.phases;
 
-import cosy.phases.Resolver.Variable;
-
 using cosy.VariableType.VariableTypeTools;
 
 class AstPrinter {
@@ -72,7 +70,7 @@ class AstPrinter {
 
     public function printExpr(expr: Expr): String {
         return switch expr {
-            case ArrayLiteral(keyword, exprs): '[' + [for (expr in exprs) ${printExpr(expr)}].join(',') + ']';
+            case ArrayLiteral(keyword, exprs): '[' + [for (expr in exprs) printExpr(expr)].join(',') + ']';
             case Assign(name, op, value): '${name.lexeme} ${op.lexeme} ${printExpr(value)}';
             case Binary(left, op, right): '${printExpr(left)} ${op.lexeme} ${printExpr(right)}';
             case Call(callee, paren, arguments): '${printExpr(callee)}(${[for (arg in arguments) printExpr(arg)].join(', ')})';

--- a/src/cosy/phases/AstPrinter.hx
+++ b/src/cosy/phases/AstPrinter.hx
@@ -56,14 +56,15 @@ class AstPrinter {
             case Let(v, init): '${v.foreign ? "foreign " : ""}${v.mut ? "mut" : "let"} ${v.name.lexeme}' + (init != null ? ' = ${printExpr(init)}' : '');
 
             case Query(keyword, queryArgs, body):
-                var s = '${keyword.lexeme} ';
-                for (arg in queryArgs) {
-                    if (arg.not) s += '!';
-                    if (arg.mut) s += 'mut ';
-                    if (arg.name != null) s += arg.name.lexeme;
-                    s += arg.structName.lexeme;
-                }
-                '$s ${printBlock(body)}';
+                final args = queryArgs.map(arg -> {
+                    final parts = [];
+                    if (arg.not) parts.push('!');
+                    if (arg.mut) parts.push('mut');
+                    if (arg.name != null) parts.push(arg.name.lexeme);
+                    parts.push(arg.structName.lexeme);
+                    parts.join(' ');
+                });
+                '${keyword.lexeme} ${args.join(", ")} ${printBlock(body)}';
         }
     }
 
@@ -92,7 +93,7 @@ class AstPrinter {
                         (i % 2 == 0 ? e.substr(1, e.length - 2) : '{$e}');
                     }
                 ].join('') + "'";
-            case StructInit(name, decls): printExprBlock(decls);
+            case StructInit(name, decls): '${name.lexeme} ${printExprBlock(decls)}';
             case Unary(op, right): '${op.lexeme}${printExpr(right)}';
             case Variable(name): name.lexeme;
             case AnonFunction(params, body, returnType):

--- a/src/cosy/phases/AstPrinter.hx
+++ b/src/cosy/phases/AstPrinter.hx
@@ -57,6 +57,8 @@ class AstPrinter {
             case Return(keyword, value): keyword.lexeme + (value != null ? ' ${printExpr(value)}' : '');
             case Struct(name, declarations): 'struct ${name.lexeme} ${printBlock(declarations)}';
             case Let(v, init): '${v.foreign ? "foreign " : ""}${v.mut ? "mut" : "let"} ${v.name.lexeme}' + (init != null ? ' = ${printExpr(init)}' : '');
+
+            case Query(keyword, queryArgs, body): throw 'not implemented'; // TODO: Implement
         }
     }
 
@@ -93,6 +95,7 @@ class AstPrinter {
                 var retType = returnType.annotated.formatType(true);
                 if (retType != '') retType = ' $retType';
                 'fn($parameters)$retType $block';
+            case Spawn(keyword, args): 'SPAWN!';
         }
     }
 

--- a/src/cosy/phases/AstPrinter.hx
+++ b/src/cosy/phases/AstPrinter.hx
@@ -51,7 +51,6 @@ class AstPrinter {
                 var block = printBlock(body);
                 '$declaration($parameters)$retType $block';
             case If(keyword, cond, then, el): '${keyword.lexeme} ${printExpr(cond)} ${printStmt(then)}' + (el != null ? ' else ${printStmt(el)}' : '');
-            case Print(keyword, e): '${keyword.lexeme} ${printExpr(e)}';
             case Return(keyword, value): keyword.lexeme + (value != null ? ' ${printExpr(value)}' : '');
             case Struct(name, declarations): 'struct ${name.lexeme} ${printBlock(declarations)}';
             case Let(v, init): '${v.foreign ? "foreign " : ""}${v.mut ? "mut" : "let"} ${v.name.lexeme}' + (init != null ? ' = ${printExpr(init)}' : '');
@@ -84,6 +83,7 @@ class AstPrinter {
                 };
             case Logical(left, op, right): '${printExpr(left)} ${op.type.match(Or) ? 'or' : 'and'} ${printExpr(right)}';
             case MutArgument(keyword, name): 'mut ${name.lexeme}';
+            case Print(keyword, e): '${keyword.lexeme} ${printExpr(e)}';
             case Set(obj, name, op, value): '${printExpr(obj)}.${name.lexeme} ${op.lexeme} ${printExpr(value)}';
             case SetIndex(obj, ranged, from, to, op, value): '${printExpr(obj)}[${formatIndexRange(ranged, from, to)}] ${op.lexeme} ${printExpr(value)}';
             case StringInterpolation(exprs): "'" + [

--- a/src/cosy/phases/CodeGenerator.hx
+++ b/src/cosy/phases/CodeGenerator.hx
@@ -113,10 +113,6 @@ class CodeGenerator {
     function genStmt(stmt: Stmt) {
         if (stmt == null) return;
         switch stmt {
-            case Print(keyword, expr):
-                add_token(keyword);
-                genExpr(expr);
-                emit(Print);
             case Let(v, init):
                 add_token(v.name);
                 genExpr(init);
@@ -266,6 +262,10 @@ class CodeGenerator {
             case Literal(v) if (Std.isOfType(v, Bool)): (v ? emit(PushTrue) : emit(PushFalse));
             case Literal(v) if (Std.isOfType(v, Float)): emit(PushNumber(v));
             case Literal(v) if (Std.isOfType(v, String)): emit(ConstantString(v));
+            case Print(keyword, expr):
+                add_token(keyword);
+                genExpr(expr);
+                emit(Print);
             case Grouping(expr): genExpr(expr);
             case Variable(name):
                 add_token(name);

--- a/src/cosy/phases/Interpreter.hx
+++ b/src/cosy/phases/Interpreter.hx
@@ -163,11 +163,12 @@ class Interpreter {
                 final include: Array<Composite.Expression> = [];
                 for (arg in queryArgs) {
                     final componentId = structIds.get(arg.structName.lexeme);
-                    include.push(Include(componentId));
+                    include.push(arg.not ? Exclude(componentId) : Include(componentId));
                 }
                 context.queryEach(Group(include), (entity, components) -> {
                     var env = new Environment(environment);
                     for (i => arg in queryArgs) {
+                        if (arg.name == null) continue;
                         env.define(arg.name.lexeme, components[i]);
                     }
                     try {

--- a/src/cosy/phases/Interpreter.hx
+++ b/src/cosy/phases/Interpreter.hx
@@ -165,22 +165,22 @@ class Interpreter {
                     final componentId = structIds.get(arg.structName.lexeme);
                     include.push(arg.not ? Exclude(componentId) : Include(componentId));
                 }
-                context.queryEach(Group(include), (entity, components) -> {
-                    var env = new Environment(environment);
-                    for (i => arg in queryArgs) {
-                        if (arg.name == null) continue;
-                        env.define(arg.name.lexeme, components[i]);
-                    }
-                    try {
+                var env = new Environment(environment); // cache the environment as an optimization
+                try {
+                    context.queryEach(Group(include), (entity, components) -> {
+                        for (i => arg in queryArgs) {
+                            if (arg.name == null) continue;
+                            env.define(arg.name.lexeme, components[i]);
+                        }
                         try {
                             executeBlock(body, env); // TODO: Is it required to create a new environment if name is null?
                         } catch (err: Continue) {
                             // do nothing
                         }
-                    } catch (err: Break) {
-                        // do nothing
-                    }
-                });
+                    });
+                } catch (err: Break) {
+                    // do nothing
+                }
         }
     }
 

--- a/src/cosy/phases/Interpreter.hx
+++ b/src/cosy/phases/Interpreter.hx
@@ -154,6 +154,23 @@ class Interpreter {
                     // Hack for hot reload to disregard already setup variables
                     if (init != null) environment.define(v.name.lexeme, value);
                 }
+            case Query(keyword, queryArgs, body):
+                Logging.println('doing some query stuff!'); // TODO: Implement
+                // TODO: Do the following for each entity returned by the query
+                var env = new Environment(environment);
+                // TODO: Get component from Entity
+                // for (arg in queryArgs) {
+                //     env.define(arg.name.lexeme, ???);
+                // }
+                try {
+                    try {
+                        executeBlock(body, env); // TODO: Is it required to create a new environment if name is null?
+                    } catch (err: Continue) {
+                        // do nothing
+                    }
+                } catch (err: Break) {
+                    // do nothing
+                }
         }
     }
 
@@ -419,6 +436,7 @@ class Interpreter {
                 }
                 structObj;
             case AnonFunction(params, body, returnType): new Function(null, params, body, environment, false, logger);
+            case Spawn(keyword, params): 42; // TODO: Implement
         }
     }
 

--- a/src/cosy/phases/Interpreter.hx
+++ b/src/cosy/phases/Interpreter.hx
@@ -171,8 +171,9 @@ class Interpreter {
                 var env = new Environment(environment); // cache the environment as an optimization
                 try {
                     context.queryEach(Group(queryExpression), (entity, components) -> {
-                        for (i => arg in queryArgs) {
-                            if (arg.name == null) continue;
+                        final includeArgs = queryArgs.filter(arg -> !arg.not);
+                        for (i => arg in includeArgs) {
+                            if (arg.name == null) continue; // TODO: Not used components should not be included in the query result at all
                             env.define(arg.name.lexeme, components[i]);
                         }
                         try {

--- a/src/cosy/phases/Interpreter.hx
+++ b/src/cosy/phases/Interpreter.hx
@@ -160,20 +160,20 @@ class Interpreter {
                     if (init != null) environment.define(v.name.lexeme, value);
                 }
             case Query(keyword, queryArgs, body):
-                final include: Array<Composite.Expression> = [];
+                final queryExpression: Array<Composite.Expression> = [];
                 for (arg in queryArgs) {
                     final componentId = structIds.get(arg.structName.lexeme);
-                    include.push(arg.not ? Exclude(componentId) : Include(componentId));
+                    queryExpression.push(arg.not ? Exclude(componentId) : Include(componentId));
                 }
                 var env = new Environment(environment); // cache the environment as an optimization
                 try {
-                    context.queryEach(Group(include), (entity, components) -> {
+                    context.queryEach(Group(queryExpression), (entity, components) -> {
                         for (i => arg in queryArgs) {
                             if (arg.name == null) continue;
                             env.define(arg.name.lexeme, components[i]);
                         }
                         try {
-                            executeBlock(body, env); // TODO: Is it required to create a new environment if name is null?
+                            executeBlock(body, env);
                         } catch (err: Continue) {
                             // do nothing
                         }

--- a/src/cosy/phases/Interpreter.hx
+++ b/src/cosy/phases/Interpreter.hx
@@ -123,7 +123,6 @@ class Interpreter {
                 environment.define(name.lexeme, new Function(name, params, body, environment, false, logger));
             case If(keyword, cond, then, el): if (isTruthy(evaluate(cond))) execute(then);
                 else if (el != null) execute(el);
-            case Print(keyword, e): Logging.println(stringify(evaluate(e)));
             case Return(keyword, value):
                 var value = if (value == null) null else evaluate(value);
                 throw new Return(value);
@@ -375,6 +374,10 @@ class Interpreter {
                     }
                 }
                 throw 'Bracket operator can only be used on arrays and strings.'; // TODO: Use RuntimeError with keyword
+            case Print(keyword, e):
+                final value = evaluate(e);
+                Logging.println(stringify(value));
+                value;
             case Set(obj, name, op, value):
                 final obj = evaluate(obj);
                 if (Std.isOfType(obj, StructInstance)) {

--- a/src/cosy/phases/Interpreter.hx
+++ b/src/cosy/phases/Interpreter.hx
@@ -142,22 +142,25 @@ class Interpreter {
                 environment.assign(name, struct);
                 structIds.set(name.lexeme, structCount++);
             case Let(v, init):
+                final name = v.name.lexeme;
+                var value: Any = uninitialized;
+                if (init != null) value = evaluate(init);
+
                 if (v.foreign) {
-                    environment.define(v.name.lexeme, compiler.foreignVariables[v.name.lexeme]);
+                    final initialValue = (compiler.foreignVariables.exists(name) ? compiler.foreignVariables[name] : value);
+                    environment.define(name, initialValue);
                     return;
                 }
 
-                var value: Any = uninitialized;
-                if (init != null) value = evaluate(init);
                 // Uncomment this if you want structs to be be passed by value instead of by reference
                 // if (Std.isOfType(value, StructInstance)) {
                 //     value = (value: StructInstance).clone();
                 // }
                 if (!hotReload) {
-                    environment.define(v.name.lexeme, value);
+                    environment.define(name, value);
                 } else {
                     // Hack for hot reload to disregard already setup variables
-                    if (init != null) environment.define(v.name.lexeme, value);
+                    if (init != null) environment.define(name, value);
                 }
             case Query(keyword, queryArgs, body):
                 final queryExpression: Array<Composite.Expression> = [];

--- a/src/cosy/phases/JavaScriptPrinter.hx
+++ b/src/cosy/phases/JavaScriptPrinter.hx
@@ -46,7 +46,7 @@ class JavaScriptPrinter {
                 if (v.foreign) return ''; // TODO: Is this correct behavior?
                 '${v.mut ? "var" : "const"} ${v.name.lexeme}' + (init != null ? ' = ${printExpr(init)}' : '') + ';';
 
-            case Query(keyword, queryArgs, body): throw 'not implemented'; // TODO: Implement
+            case Query(keyword, queryArgs, body): throw 'ECS functionality is not supported for the JavaScript target.';
         }
     }
 
@@ -106,7 +106,7 @@ class JavaScriptPrinter {
                 var parameters = [for (token in params) token.name.lexeme].join(', ');
                 var block = printStmt(Block(body));
                 'function ($parameters) $block';
-            case Spawn(keyword, args): 'SPAWN!';
+            case Spawn(keyword, args): throw 'ECS functionality is not supported for the JavaScript target.';
         }
     }
 }

--- a/src/cosy/phases/JavaScriptPrinter.hx
+++ b/src/cosy/phases/JavaScriptPrinter.hx
@@ -39,7 +39,6 @@ class JavaScriptPrinter {
                 var block = printStmt(Block(body));
                 '$declaration($parameters) $block';
             case If(keyword, cond, then, el): 'if (${printExpr(cond)}) ${printStmt(then)}' + (el != null ? ' else ${printStmt(el)}' : '');
-            case Print(keyword, e): 'console.log(${printExpr(e)});';
             case Struct(name, declarations): '// ${name.lexeme} struct';
             case Return(keyword, value): 'return' + (value != null ? ' ${printExpr(value)}' : '') + ';';
             case Let(v, init):
@@ -87,6 +86,9 @@ class JavaScriptPrinter {
                     '$v';
                 };
             case Logical(left, op, right): '${printExpr(left)} ${op.type.match(Or) ? '||' : '&&'} ${printExpr(right)}';
+            case Print(keyword, e):
+                final value = printExpr(e);
+                'console.log($value) || $value';
             case Set(obj, name, op, value): '${printExpr(obj)}.${name.lexeme} ${op.lexeme} ${printExpr(value)}';
             case SetIndex(obj, ranged, from, to, op, value):
                 if (ranged) throw 'Ranged indexing not supported on JavaScript yet!';

--- a/src/cosy/phases/JavaScriptPrinter.hx
+++ b/src/cosy/phases/JavaScriptPrinter.hx
@@ -45,6 +45,8 @@ class JavaScriptPrinter {
             case Let(v, init):
                 if (v.foreign) return ''; // TODO: Is this correct behavior?
                 '${v.mut ? "var" : "const"} ${v.name.lexeme}' + (init != null ? ' = ${printExpr(init)}' : '') + ';';
+
+            case Query(keyword, queryArgs, body): throw 'not implemented'; // TODO: Implement
         }
     }
 
@@ -104,6 +106,7 @@ class JavaScriptPrinter {
                 var parameters = [for (token in params) token.name.lexeme].join(', ');
                 var block = printStmt(Block(body));
                 'function ($parameters) $block';
+            case Spawn(keyword, args): 'SPAWN!';
         }
     }
 }

--- a/src/cosy/phases/Optimizer.hx
+++ b/src/cosy/phases/Optimizer.hx
@@ -24,7 +24,6 @@ class Optimizer {
             case Block(statements): Block(optimizeStmts(statements));
             case Expression(e): Expression(optimizeExpr(e));
             case If(keyword, cond, then, el): If(keyword, optimizeExpr(cond), optimizeStmt(then), (el != null ? optimizeStmt(el) : null));
-            case Print(keyword, e): Print(keyword, optimizeExpr(e));
             case Let(v, init): Let(v, (init != null ? optimizeExpr(init) : init));
             case Return(keyword, value): Return(keyword, (value != null ? optimizeExpr(value) : null));
             case _: stmt;
@@ -76,6 +75,7 @@ class Optimizer {
                         });
                     case _: Expr.Logical(l, op, r);
                 }
+            case Print(keyword, e): Print(keyword, optimizeExpr(e));
             case StringInterpolation(parts): Expr.StringInterpolation(parts.map(optimizeExpr));
             case _: expr;
         }

--- a/src/cosy/phases/Parser.hx
+++ b/src/cosy/phases/Parser.hx
@@ -500,7 +500,7 @@ class Parser {
         if (!check(RightParen)) {
             do {
                 if (args.length >= 255) error(peek(), 'Cannot have more than 255 arguments');
-                args.push(expression()); // TODO: Add a way to validate that this is a named struct at this point?
+                args.push(expression());
             } while (match([Comma]));
         }
         consume(RightParen, 'Expect ")" after arguments.');

--- a/src/cosy/phases/Parser.hx
+++ b/src/cosy/phases/Parser.hx
@@ -102,13 +102,13 @@ class Parser {
 
         // query Entity e, Position p, Velocity _, not Health { ... }
         final queryArgs: Array<QueryArg> = [];
-        while (!check(LeftBrace)) {
+        do {
             final mut = match([Mut]);
             final structName = consume(Identifier, 'Expect struct name.');
             if (!isValidNamedStruct(structName)) error(structName, '"${structName.lexeme}" does not name a struct.');
             final name = consume(Identifier, 'Expect variable name.');
             queryArgs.push({structName: structName, name: name, mut: mut});
-        }
+        } while (match([Comma]));
 
         consume(LeftBrace, 'Expect "{" before loop body.');
         var body = block();
@@ -494,7 +494,7 @@ class Parser {
         if (!check(RightParen)) {
             do {
                 if (args.length >= 255) error(peek(), 'Cannot have more than 255 arguments');
-                args.push(expression()); // TODO: Add a way to validate that this is a named struct?
+                args.push(expression()); // TODO: Add a way to validate that this is a named struct at this point?
             } while (match([Comma]));
         }
         consume(RightParen, 'Expect ")" after arguments.');

--- a/src/cosy/phases/Parser.hx
+++ b/src/cosy/phases/Parser.hx
@@ -103,10 +103,11 @@ class Parser {
         // query Entity e, Position p, Velocity _, not Health { ... }
         final queryArgs: Array<QueryArg> = [];
         while (!check(LeftBrace)) {
-            var structName = consume(Identifier, 'Expect struct name.');
+            final mut = match([Mut]);
+            final structName = consume(Identifier, 'Expect struct name.');
             if (!isValidNamedStruct(structName)) error(structName, '"${structName.lexeme}" does not name a struct.');
-            var name = consume(Identifier, 'Expect variable name.');
-            queryArgs.push({structName: structName, name: name});
+            final name = consume(Identifier, 'Expect variable name.');
+            queryArgs.push({structName: structName, name: name, mut: mut});
         }
 
         consume(LeftBrace, 'Expect "{" before loop body.');

--- a/src/cosy/phases/Parser.hx
+++ b/src/cosy/phases/Parser.hx
@@ -38,6 +38,7 @@ class Parser {
     function statement(): Stmt {
         // TODO: this list of match can be optimized by doing switch tokens[current]
         if (match([For])) return forStatement();
+        if (match([Query])) return queryStatement();
         if (match([If])) return ifStatement();
         if (match([Print])) return printStatement();
         if (match([Return])) return returnStatement();
@@ -94,6 +95,24 @@ class Parser {
 
             ForCondition(keyword, condition, body);
         }
+    }
+
+    function queryStatement(): Stmt {
+        var keyword = previous();
+
+        // query Entity e, Position p, Velocity _, not Health { ... }
+        final queryArgs: Array<QueryArg> = [];
+        while (!check(LeftBrace)) {
+            var structName = consume(Identifier, 'Expect struct name.');
+            if (!isValidNamedStruct(structName)) error(structName, '"${structName.lexeme}" does not name a struct.');
+            var name = consume(Identifier, 'Expect variable name.');
+            queryArgs.push({structName: structName, name: name});
+        }
+
+        consume(LeftBrace, 'Expect "{" before loop body.');
+        var body = block();
+
+        return Query(keyword, queryArgs, body);
     }
 
     function ifStatement(): Stmt {
@@ -404,6 +423,7 @@ class Parser {
         if (match([True])) return Literal(true);
         if (match([Number])) return Literal(previous().literal);
         if (match([String])) return string();
+        if (match([Spawn])) return spawn();
         if (match([Fn])) return funcBody("function", false);
         if (match([Identifier])) return identifier();
         if (match([Mut])) return MutArgument(previous(), consume(Identifier, 'Expect variable name after "mut".'));
@@ -464,6 +484,21 @@ class Parser {
         } else {
             return expr;
         }
+    }
+
+    function spawn(): Expr {
+        var keyword = previous();
+        consume(LeftParen, 'Expect "(" after "spawn" keyword.');
+        var args: Array<Expr> = [];
+        if (!check(RightParen)) {
+            do {
+                if (args.length >= 255) error(peek(), 'Cannot have more than 255 arguments');
+                args.push(expression()); // TODO: Add a way to validate that this is a named struct?
+            } while (match([Comma]));
+        }
+        consume(RightParen, 'Expect ")" after arguments.');
+
+        return Spawn(keyword, args);
     }
 
     function isValidNamedStruct(token: Token): Bool {

--- a/src/cosy/phases/Parser.hx
+++ b/src/cosy/phases/Parser.hx
@@ -107,7 +107,7 @@ class Parser {
             final mut = match([Mut]);
             final structName = consume(Identifier, 'Expect struct name.');
             if (!isValidNamedStruct(structName)) error(structName, '"${structName.lexeme}" does not name a struct.');
-            final name = not ? null : consume(Identifier, 'Expect variable name.');
+            final name = (check(Identifier) ? advance() : null);
             queryArgs.push({
                 structName: structName,
                 name: name,
@@ -162,7 +162,7 @@ class Parser {
         var type = paramType();
 
         var initializer = null;
-        if (!foreign && match([Equal])) initializer = expression();
+        if (match([Equal])) initializer = expression();
 
         return Let({
             name: name,

--- a/src/cosy/phases/Parser.hx
+++ b/src/cosy/phases/Parser.hx
@@ -40,7 +40,6 @@ class Parser {
         if (match([For])) return forStatement();
         if (match([Query])) return queryStatement();
         if (match([If])) return ifStatement();
-        if (match([Print])) return printStatement();
         if (match([Return])) return returnStatement();
         if (match([Break])) return Break(previous());
         if (match([Continue])) return Continue(previous());
@@ -130,7 +129,7 @@ class Parser {
         return If(keyword, condition, then, el);
     }
 
-    function printStatement(): Stmt {
+    function printExpression(): Expr {
         var keyword = previous();
         var value = expression();
         return Print(keyword, value);
@@ -430,6 +429,7 @@ class Parser {
         if (match([True])) return Literal(true);
         if (match([Number])) return Literal(previous().literal);
         if (match([String])) return string();
+        if (match([Print])) return printExpression();
         if (match([Spawn])) return spawn();
         if (match([Fn])) return funcBody("function", false);
         if (match([Identifier])) return identifier();

--- a/src/cosy/phases/Parser.hx
+++ b/src/cosy/phases/Parser.hx
@@ -103,11 +103,17 @@ class Parser {
         // query Entity e, Position p, Velocity _, not Health { ... }
         final queryArgs: Array<QueryArg> = [];
         do {
+            final not = match([Bang]);
             final mut = match([Mut]);
             final structName = consume(Identifier, 'Expect struct name.');
             if (!isValidNamedStruct(structName)) error(structName, '"${structName.lexeme}" does not name a struct.');
-            final name = consume(Identifier, 'Expect variable name.');
-            queryArgs.push({structName: structName, name: name, mut: mut});
+            final name = not ? null : consume(Identifier, 'Expect variable name.');
+            queryArgs.push({
+                structName: structName,
+                name: name,
+                mut: mut,
+                not: not
+            });
         } while (match([Comma]));
 
         consume(LeftBrace, 'Expect "{" before loop body.');

--- a/src/cosy/phases/Resolver.hx
+++ b/src/cosy/phases/Resolver.hx
@@ -122,6 +122,15 @@ class Resolver {
                 resolveStmts(declarations);
                 endScope();
                 currentStruct = None;
+            case Query(keyword, queryArgs, body):
+                beginScope();
+                for (arg in queryArgs) {
+                    declare(arg.name, false); // TODO: Handle `mut`
+                    define(arg.name, false); // TODO: Handle `mut`
+                }
+                if (body.length == 0) logger.error(keyword, 'Query body is empty.');
+                resolveStmts(body);
+                endScope();
         }
     }
 
@@ -191,8 +200,8 @@ class Resolver {
                     }
                 }
                 resolveLocal(expr, name, true);
-            case Literal(_):
-            // skip
+            case Spawn(keyword, args): resolveExprs(args);
+            case Literal(_): // skip
             case AnonFunction(params, body, returnType): resolveFunction(null, params, body, Function, false);
         }
     }

--- a/src/cosy/phases/Resolver.hx
+++ b/src/cosy/phases/Resolver.hx
@@ -57,8 +57,9 @@ class Resolver {
             case Break(keyword):
             case Continue(keyword):
             case Let(v, init):
-                if (v.foreign && !compiler.foreignVariables.exists(v.name.lexeme)) logger.error(v.name, 'Foreign variable not set.');
-                if (!snakeCaseRegex.match(v.name.lexeme)) logger.error(v.name, 'Variable names must use snake_case.');
+                final name = v.name.lexeme;
+                if (v.foreign && init == null && !compiler.foreignVariables.exists(name)) logger.error(v.name, 'Foreign variable not set.');
+                if (!snakeCaseRegex.match(name)) logger.error(v.name, 'Variable names must use snake_case.');
                 var member = currentStruct.match(Struct);
                 markTypeAsRead(v.type);
                 declare(v.name, v.mut, member);

--- a/src/cosy/phases/Resolver.hx
+++ b/src/cosy/phases/Resolver.hx
@@ -125,8 +125,8 @@ class Resolver {
             case Query(keyword, queryArgs, body):
                 beginScope();
                 for (arg in queryArgs) {
-                    declare(arg.name, false); // TODO: Handle `mut`
-                    define(arg.name, false); // TODO: Handle `mut`
+                    declare(arg.name, arg.mut);
+                    define(arg.name, arg.mut);
                 }
                 if (body.length == 0) logger.error(keyword, 'Query body is empty.');
                 resolveStmts(body);
@@ -175,7 +175,7 @@ class Resolver {
                 switch obj {
                     case Variable(objName):
                         var variable = findInScopes(objName);
-                        if (variable != null && !variable.mutable) logger.error(name, 'Cannot reassign properties on non-mutable struct.');
+                        if (variable != null && !variable.mutable) logger.error(name, 'Cannot set properties on non-mutable struct.');
                     case Get(getObj, getName): // ignore???
                     case Call(callee, paren, arguments):
                         resolveExpr(callee);

--- a/src/cosy/phases/Resolver.hx
+++ b/src/cosy/phases/Resolver.hx
@@ -125,6 +125,7 @@ class Resolver {
             case Query(keyword, queryArgs, body):
                 beginScope();
                 for (arg in queryArgs) {
+                    if (arg.name == null) continue;
                     declare(arg.name, arg.mut);
                     define(arg.name, arg.mut);
                 }

--- a/src/cosy/phases/Resolver.hx
+++ b/src/cosy/phases/Resolver.hx
@@ -100,7 +100,6 @@ class Resolver {
                 define(name);
                 resolveFunction(name, params, body, Function, foreign);
             case Expression(e): resolveExpr(e);
-            case Print(keyword, e): resolveExpr(e);
             case If(keyword, cond, then, el):
                 switch cond {
                     case Literal(v) if (Std.isOfType(v, Bool)): logger.error(keyword, 'This condition is always $v.');
@@ -170,6 +169,7 @@ class Resolver {
                 if (from != null) resolveExpr(from);
                 if (to != null) resolveExpr(to);
             case MutArgument(keyword, name): resolveLocal(expr, name, true);
+            case Print(keyword, e): resolveExpr(e);
             case Set(obj, name, op, value):
                 resolveExpr(value);
                 resolveExpr(obj);

--- a/src/cosy/phases/Scanner.hx
+++ b/src/cosy/phases/Scanner.hx
@@ -10,7 +10,7 @@ class Scanner {
     static final keywords = [
         'and' => And, 'break' => Break, 'continue' => Continue, 'else' => Else, 'false' => False, 'for' => For, 'foreign' => Foreign, 'fn' => Fn, 'in' => In,
         'if' => If, 'mut' => Mut, 'or' => Or, 'print' => Print, 'return' => Return, 'struct' => Struct, 'true' => True, 'let' => Let, 'Bool' => BooleanType,
-        'Num' => NumberType, 'Str' => StringType, 'Void' => VoidType, 'Fn' => FunctionType, 'Array' => ArrayType,
+        'Num' => NumberType, 'Str' => StringType, 'Void' => VoidType, 'Fn' => FunctionType, 'Array' => ArrayType, 'spawn' => Spawn, 'query' => Query,
     ];
 
     var start = 0;

--- a/src/cosy/phases/Typer.hx
+++ b/src/cosy/phases/Typer.hx
@@ -165,14 +165,7 @@ class Typer {
                     mut: false,
                     foreign: false,
                 });
-            case Query(keyword, queryArgs, body):
-                // for (arg in queryArgs) {
-                //     final argType = typeExpr(arg);
-                //     if (!argType.match(NamedStruct)) {
-                //         logger.error(keyword, 'Expected variable to be a named struct but got ${formatType(argType)}.');
-                //     }
-                // }
-                typeStmts(body);
+            case Query(keyword, queryArgs, body): typeStmts(body);
         }
     }
 

--- a/src/cosy/phases/Typer.hx
+++ b/src/cosy/phases/Typer.hx
@@ -165,6 +165,14 @@ class Typer {
                     mut: false,
                     foreign: false,
                 });
+            case Query(keyword, queryArgs, body):
+                // for (arg in queryArgs) {
+                //     final argType = typeExpr(arg);
+                //     if (!argType.match(NamedStruct)) {
+                //         logger.error(keyword, 'Expected variable to be a named struct but got ${formatType(argType)}.');
+                //     }
+                // }
+                typeStmts(body);
         }
     }
 
@@ -498,6 +506,7 @@ class Typer {
                 }
                 structType.type;
             case AnonFunction(params, body, returnType): handleFunc(null, params, body, returnType, false);
+            case Spawn(keyword, params): Entity;
             case Literal(v) if (Std.isOfType(v, Float)): Number;
             case Literal(v) if (Std.isOfType(v, String)): Text;
             case Literal(v) if (Std.isOfType(v, Bool)): Boolean;

--- a/src/cosy/phases/Typer.hx
+++ b/src/cosy/phases/Typer.hx
@@ -218,6 +218,7 @@ class Typer {
             case Assign(name, op, value):
                 final assigningType = typeExpr(value);
                 final v = variableTypes.get(name.lexeme);
+                if (v == null) return Void;
                 final varType = v.type;
                 if (varType.match(Unknown)) {
                     v.type = assigningType;
@@ -489,7 +490,7 @@ class Typer {
                             if (!matchType(valueType,
                                 memberType.type)) logger.error(name,
                                     'Expected value to be of type ${formatType(memberType.type)} but got ${formatType(valueType)}');
-                        case _: throw 'unexpected';
+                        case _: logger.error(structName, 'Expected struct variable assignment.');
                     }
                 }
                 for (memberName => memberMeta in structsMeta[structName.lexeme].members) {

--- a/src/cosy/phases/Typer.hx
+++ b/src/cosy/phases/Typer.hx
@@ -110,10 +110,6 @@ class Typer {
             case ForCondition(keyword, cond, body): typeStmts(body);
             case Function(name, params, body, returnType, foreign): handleFunc(name, params, body, returnType, foreign);
             case Expression(e): typeExpr(e);
-            case Print(keyword, e):
-                var type = typeExpr(e);
-                if (type.match(Void)) logger.error(keyword, 'Cannot print values of type void.');
-                type;
             case If(keyword, cond, then, el):
                 var condType = typeExpr(cond);
                 switch condType {
@@ -407,6 +403,10 @@ class Typer {
                 var v = variableTypes.get(name.lexeme);
                 if (!v.mut) logger.error(name, 'Only mutable structs and arrays can be passed as "mut". You passed ${formatType(v.type, false)}.');
                 v.type;
+            case Print(keyword, e):
+                var type = typeExpr(e);
+                if (type.match(Void)) logger.error(keyword, 'Cannot print values of type void.');
+                type;
             case Set(obj, name, op, value):
                 var objType = typeExpr(obj);
                 objType = switch objType {

--- a/test/Testbed.cosy
+++ b/test/Testbed.cosy
@@ -1,2 +1,19 @@
+struct Position {
+    mut x Num
+    mut y Num
+}
+// struct Velocity {
+//     mut x Num
+//     mut y Num
+// }
+
+print Position { x = 0, y = 0 }
+
+let e = spawn(Position { x = 3.5, y = 2.1 })
+print e
+
+query Position p {
+	print p
+}
 
 print 'done'

--- a/test/Testbed.cosy
+++ b/test/Testbed.cosy
@@ -6,9 +6,14 @@ struct Velocity {
     mut x Num
     mut y Num
 }
+struct Age {
+    mut age Num
+}
 
 let e = spawn(Position { x = 3.5, y = 2.1 }, Velocity { x = 1.0, y = -3.2 })
 print e
+let e2 = spawn(Position { x = 0.5, y = 0.1 }, Age { age = 42 })
+print e2
 
 query mut Position p, Velocity v {
     print 'Printing p and v:'
@@ -17,11 +22,10 @@ query mut Position p, Velocity v {
 	p.x += v.x
     p.y += v.y
 }
-query Position p, Velocity v {
-    print 'Printing p and v:'
+//query Entity e, !Velocity {
+query Position p {
+    print 'PART 2: Printing p:'
 	print p
-	print v
-    print '!!!'
 }
 
 print 'done'

--- a/test/Testbed.cosy
+++ b/test/Testbed.cosy
@@ -2,18 +2,26 @@ struct Position {
     mut x Num
     mut y Num
 }
-// struct Velocity {
-//     mut x Num
-//     mut y Num
-// }
+struct Velocity {
+    mut x Num
+    mut y Num
+}
 
-print Position { x = 0, y = 0 }
-
-let e = spawn(Position { x = 3.5, y = 2.1 })
+let e = spawn(Position { x = 3.5, y = 2.1 }, Velocity { x = 1.0, y = -3.2 })
 print e
 
-query Position p {
+query mut Position p, Velocity v {
+    print 'Printing p and v:'
 	print p
+	print v
+	p.x += v.x
+    p.y += v.y
+}
+query Position p, Velocity v {
+    print 'Printing p and v:'
+	print p
+	print v
+    print '!!!'
 }
 
 print 'done'

--- a/test/scripts/type-checking.cosy.stdout
+++ b/test/scripts/type-checking.cosy.stdout
@@ -170,7 +170,7 @@
 245 |     struct S { mut s Num }
 246 |     fn mutate_struct(s) {
 247 |         s.s = 666
-                ^ Cannot reassign properties on non-mutable struct.
+                ^ Cannot set properties on non-mutable struct.
 248 |     }
 249 |     mutate_struct(S { s = 3 })
 

--- a/wishlist.md
+++ b/wishlist.md
@@ -129,7 +129,7 @@ fun x() { print "hej" }
 - [ ] A way to initialize a list with a size (like in C++; `vector<int>(height, vector<int>(width, 0)))`)
 - [ ] Find a more elegant way of handling variable/parameter/return type/loop variable/named struct mutability. I may have to replace some enums with structures.
 - [ ] Replace nominal typing with structural typing?
-- [ ] Make `print` return the value it prints
+- [x] Make `print` return the value it prints
 
 # Project wishlist
 - [ ] Make a syntax highlighting extension for vscode

--- a/wishlist.md
+++ b/wishlist.md
@@ -163,7 +163,7 @@ fun x() { print "hej" }
 - [ ] Make the playground work again
 
 ## Long shots
-- [ ] Built-in ECS functionality somehow
+- [x] Built-in ECS functionality somehow
 - [ ] Fibers á la Wren
 - [ ] Yield functionality (generators or coroutines)
 - [ ] Hot reloading

--- a/wishlist.md
+++ b/wishlist.md
@@ -128,6 +128,7 @@ fun x() { print "hej" }
 - [ ] Make an annotation for memorizing a function (i.e. cache inputs => output)
 - [ ] A way to initialize a list with a size (like in C++; `vector<int>(height, vector<int>(width, 0)))`)
 - [ ] Find a more elegant way of handling variable/parameter/return type/loop variable/named struct mutability. I may have to replace some enums with structures.
+- [ ] Replace nominal typing with structural typing?
 
 # Project wishlist
 - [ ] Make a syntax highlighting extension for vscode
@@ -159,14 +160,14 @@ fun x() { print "hej" }
 - [x] Use a code linter (https://github.com/HaxeCheckstyle/haxe-checkstyle)
 - [ ] Put on Haxelib
 - [ ] Make auto-generated documentation for the Cosy standard library (see https://oaklang.org/lib)
+- [ ] Make the playground work again
 
 ## Long shots
 - [ ] Built-in ECS functionality somehow
+- [ ] Fibers á la Wren
 - [ ] Yield functionality (generators or coroutines)
 - [ ] Hot reloading
 - [ ] Make a web-based app for creative coding (á la a _very_ simplified p5.js)
 - [ ] Easy to integrate into C/C++ projects
-- [ ] Fibers á la Wren
-- [ ] Built-in threading
 - [ ] Make a Cosy debugger (https://www.google.com/search?q=how+to+write+a+debugger, https://microsoft.github.io/debug-adapter-protocol/)
-- [ ] Cosy Roguelike (see https://github.com/Kode/Kha/wiki/Tutorials, https://github.com/lewislepton/kha-examples, https://github.com/RblSb/khaguide)
+- [ ] Cosy Roguelike

--- a/wishlist.md
+++ b/wishlist.md
@@ -11,7 +11,7 @@ fun x() { print "hej" }
 - [x] Compile-time error to redefine variable/function
 - [x] No semi-colons
 - [ ] Change assignment to be a statement instead of an expression?
-- [ ] Change more statements into expressions
+- [ ] Change more statements into expressions (see http://journal.stuffwithstuff.com/2023/01/03/type-checking-if-expressions/)
 - [x] No variable shadowing
 - [x] Avoid local function variables overwriting function arguments (e.g. `let a = "local"`)
 - [x] Static analysis for
@@ -129,6 +129,7 @@ fun x() { print "hej" }
 - [ ] A way to initialize a list with a size (like in C++; `vector<int>(height, vector<int>(width, 0)))`)
 - [ ] Find a more elegant way of handling variable/parameter/return type/loop variable/named struct mutability. I may have to replace some enums with structures.
 - [ ] Replace nominal typing with structural typing?
+- [ ] Make `print` return the value it prints
 
 # Project wishlist
 - [ ] Make a syntax highlighting extension for vscode


### PR DESCRIPTION
Integrate [Composite](https://github.com/anissen/composite) into Cosy to be able to use entity component functionality directly as part of the language.

This is especially useful for applications with a lot of objects that can change properties interactively. However, it can also be convenient as a sort of in-memory database for a wider variety of applications.

Limitations:
- Composite library is currently linked in. This only works locally.
- Still work-in-progress.

---

Example usage:
```rust
struct Position {
    mut x Num
    mut y Num
}
struct Velocity {
    mut x Num
    mut y Num
}

// create entity
spawn(
    Position { x = 200, y = 200 }, 
    Velocity { x = 1.2, y = -3.4 }
)

// query entities
query mut Position p, Velocity v {
    p.x += v.x * delta
    p.y += v.y * delta
}
```